### PR TITLE
add standard bsd 3 clause license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2023, TinyStacks
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,1 +1,2 @@
-
+1. Add BSD 3-Clause license
+1. Add description to package.json

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "prepare": "husky install"
   },
   "author": "",
-  "license" : "BSD-3-Clause",
+  "license": "BSD-3-Clause",
   "dependencies": {
     "colors": "^1.4.0",
     "commander": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tinystacks/precloud",
   "version": "1.0.10",
-  "description": "## CLI Options",
+  "description": "An open source command line interface that runs checks on infrastructure as code to catch potential deployment issues before deploying.",
   "main": "dist/exported-types.js",
   "files": [
     "dist"
@@ -35,7 +35,7 @@
     "prepare": "husky install"
   },
   "author": "",
-  "license": "ISC",
+  "license" : "BSD-3-Clause",
   "dependencies": {
     "colors": "^1.4.0",
     "commander": "^10.0.0",


### PR DESCRIPTION
## Pull Request Type
 - [ ] Feature
 - [ ] Bug Fix
 - [x] Non-bug patch

## Link to Notion Task or Github Issue
N/A - ycombinator feedback

## Summary of Patch
1. Adds a standard BSD 3-Clause license to the repo.
2. Adds a description to package.json; this doubles as a suggestion for the description to put in the About section of the Github repository.

## Other Details
Should we agree on this license, we should add it to the default plugins as well.